### PR TITLE
feat: 一般社団法人WebDINO Japanの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Svelte/SvelteKitを採用している日本企業まとめ（随時更新）
 ### 株式会社アンドパッド
 - [NuxtもNextもSvelteも推し！フロントエンドエンジニアがアンドパッドでみつけた意外な夢](https://sg.wantedly.com/companies/andpad/post_articles/362007)
 
+### 一般社団法人WebDINO Japan
+- [Web VideoMark (ブラウザ拡張機能のOSSリポジトリ)](https://github.com/videomark/videomark)
+
 ### 株式会社エイチーム
 - [ハナユメのフロントエンドにSvelte/SvelteKitを採用しています](https://techblog.a-tm.co.jp/entry/2024/10/22/164045)
 - [Svelte をプロダクトに導入した話](https://speakerdeck.com/oekazuma/svelte-wopurodakutonidao-ru-sitahua)


### PR DESCRIPTION
記事や登壇資料を公開している企業の掲載がメインになっておりますが、実装のソースコードを公開しているケースなんかはどうでしょうか。(こちらのリポジトリがふと目に入ったので PR たててみました)

そういうのは違う、であれば適当に却下されてください＆ウェブディノという読みで五十音順に入れましたが Alphabetical Order の方で末尾でも良いです。

ご判断お任せします。